### PR TITLE
Handle missing ArgumentList in winget helper

### DIFF
--- a/Reinstall-Apps.ps1
+++ b/Reinstall-Apps.ps1
@@ -230,7 +230,11 @@ function Invoke-Winget {
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = "winget"
-    $psi.ArgumentList.AddRange($Args)
+    if ($psi.PSObject.Properties.Name -contains 'ArgumentList' -and $null -ne $psi.ArgumentList) {
+        $psi.ArgumentList.AddRange($Args)
+    } else {
+        $psi.Arguments = ($Args -join ' ')
+    }
     $psi.UseShellExecute = $false
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError  = $true


### PR DESCRIPTION
## Summary
- avoid null reference when ProcessStartInfo.ArgumentList is unavailable by falling back to Arguments

## Testing
- `pwsh -NoProfile -File ./Reinstall-Apps.ps1 -DryRun` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689b1031ca9483218862017d77be9389