### PR TITLE
Handle missing ArgumentList and detect winget errors

### DIFF
--- a/Reinstall-Apps.ps1
+++ b/Reinstall-Apps.ps1
@@ -230,7 +230,11 @@ function Invoke-Winget {
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = "winget"
-    $psi.ArgumentList.AddRange($Args)
+    if ($psi.PSObject.Properties.Name -contains 'ArgumentList' -and $null -ne $psi.ArgumentList) {
+        $psi.ArgumentList.AddRange($Args)
+    } else {
+        $psi.Arguments = ($Args -join ' ')
+    }
     $psi.UseShellExecute = $false
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError  = $true
@@ -243,7 +247,22 @@ function Invoke-Winget {
     if ($stdout) { Write-Log $stdout.Trim() }
     if ($stderr) { Write-Log $stderr.Trim() "WARN" }
 
-    return $proc.ExitCode
+    $exit = $proc.ExitCode
+    $combined = $stdout + "`n" + $stderr
+    $patterns = @(
+        'No installed package found',
+        'No package found matching input criteria',
+        'More help can be found'
+    )
+    foreach ($p in $patterns) {
+        if ($combined -match [regex]::Escape($p)) {
+            Write-Log "winget output indicates failure: $p" "WARN"
+            if ($exit -eq 0) { $exit = 1 }
+            break
+        }
+    }
+
+    return $exit
 }
 
 function Uninstall-App {


### PR DESCRIPTION
## Summary
- avoid null reference when ProcessStartInfo.ArgumentList is unavailable by falling back to Arguments
- treat winget operations as failed when output contains common error/help messages

## Testing
- `pwsh -NoProfile -File ./Reinstall-Apps.ps1 -DryRun` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689b1031ca9483218862017d77be9389